### PR TITLE
fix typo

### DIFF
--- a/Zc-specification/cm_mvsa01.adoc
+++ b/Zc-specification/cm_mvsa01.adoc
@@ -3,7 +3,7 @@
 === cm.mvsa01
 
 Synopsis::
-Move two s0-s7 registers into a0-a1
+Move a0-a1 into two registers of s0-s7
 
 Mnemonic::
 cm.mvsa01 _sreg1_, _sreg2_
@@ -32,7 +32,7 @@ cm.mvsa01 sreg1, sreg2
 --
 
 Description::
-This instruction moves _a0_ into _sreg1_ and _a1_ and _sreg2_.  _sreg1_ and _sreg2_ must be different.
+This instruction moves _a0_ into _sreg1_ and _a1_ into _sreg2_.  _sreg1_ and _sreg2_ must be different.
 The execution is atomic, so it is not possible to observe state where only one of _sreg1_ or _sreg2_ has been updated.
 
 The encoding uses _sreg_ number specifiers instead of _xreg_ number specifiers to save encoding space. 


### PR DESCRIPTION
`cm.mvsa01` and `cm.mva01s` has same synopsis

so i try to understand and fixed it.