### PR TITLE
Fixes couple of typos

### DIFF
--- a/Zc-specification/changes_since_v0.50.adoc
+++ b/Zc-specification/changes_since_v0.50.adoc
@@ -90,7 +90,7 @@ Note that the .E extension versions for the EABI will be specified in the future
 | C.PUSH     | CM.PUSH    | Y                 | Y                  | areg_list no longer supported
 | C.POP      | CM.POP     | Y                 | Y                  | 
 | C.POPRET   | CM.POPRET  | Y                 | Y                  | CM.POPRET doesn't return a value
-| C.POPRET   | CM.POPRETZ | Y                 | Y                  | seperate encoding for return zero
+| C.POPRET   | CM.POPRETZ | Y                 | Y                  | separate encoding for return zero
 |====================================================================================
 
 = Instructions in v0.50 but *not* in v0.70

--- a/Zc-specification/readme.md
+++ b/Zc-specification/readme.md
@@ -1,6 +1,6 @@
-This directory has the latest draft scpecification for the Zc extensions, without the PDF build.
+This directory has the latest draft specification for the Zc extensions, without the PDF build.
 
-To see the lastest built version go to:
+To see the latest built version go to:
 
 https://github.com/riscv/riscv-code-size-reduction/tags
 


### PR DESCRIPTION
I ran aspell on the whole repo, and it found 3 typos, all outside the main spec doc, but I guess there should none 

Superceed #188 