### PR TITLE
typos, and clarification that Zcmp/Zcmb are for embedded CPUs

### DIFF
--- a/Zc-specification/Zc.adoc
+++ b/Zc-specification/Zc.adoc
@@ -70,14 +70,14 @@ Zcm* all reuse the encodings for _c.fld_, _c.fsd_, _c.fldsp_, _c.fsdsp_.
 |c.zext.w       |        |        |        |yes     |        |    
 |c.mul          |        |        |        |yes     |        |    
 |c.not          |        |        |        |yes     |        |    
-7+|*PUSH/POP and double move which overlap with _c.fsdsp_*
+7+|*PUSH/POP and double move which overlap with _c.fsdsp_. Complex operations intended for embedded CPUs*
 |cm.push        |        |        |        |        |yes     |
 |cm.pop         |        |        |        |        |yes     |
 |cm.popret      |        |        |        |        |yes     |
 |cm.popretz     |        |        |        |        |yes     |
 |cm.mva01s      |        |        |        |        |yes     |
 |cm.mvsa01      |        |        |        |        |yes     |
-7+|*Table jump*              
+7+|*Table jump which overlaps with _c.fsdsp_. Complex operations intended for embedded CPUs*
 |cm.jt          |        |        |        |        |        |yes     
 |cm.jalt        |        |        |        |        |        |yes     
 |====================================================================================
@@ -89,7 +89,7 @@ The Zca extension is added as way to refer to instructions in the C extension th
 
 Therefore it _excluded_ all 16-bit floating point loads and stores: _c.flw_, _c.flwsp_, _c.fsw_, _c.fswsp_, _c.fld_, _c.fldsp_, _c.fsd_, _c.fsdsp_.
 
-NOTE: the the C extension only includes F/D instructions when D and F are also specified
+NOTE: the C extension only includes F/D instructions when D and F are also specified
 
 [#Zcf]
 === Zcf (RV32 only)
@@ -113,6 +113,8 @@ The Zcd extension depends on the <<Zca>> extension.
 Zcb has simple code-size saving instructions which are easy to implement on all CPUs.
 
 All proposed encodings are currently reserved for all architectures, and have no conflicts with any existing extensions.
+
+NOTE: Zcb can be implemented on _any_ CPU as the instructions are 16-bit versions of existing 32-bit instructions from the application class profile.
 
 The Zcb extension depends on the <<Zca>> extension.
 
@@ -203,6 +205,8 @@ The Zcmp extension is a set of instructions which may be executed as a series of
 This extension reuses some encodings from _c.fsdsp_.  Therefore it is _incompatible_ with <<Zcd>>,
  which is included when C and D extensions are both present. 
 
+NOTE: Zcmp is primarily targeted at embedded class CPUs due to implementation complexity. Additionally, it is not compatible with architecture class profiles.
+
 The Zcmp extension depends on the <<Zca>> extension.
 
 The PUSH/POP assembly syntax uses several variables, the meaning of which are:
@@ -262,6 +266,8 @@ state enable if Smstateen is implemented. See <<csrs-jvt>> for details.
 
 This extension reuses some encodings from _c.fsdsp_.  Therefore it is _incompatible_ with <<Zcd>>,
  which is included when C and D extensions are both present. 
+
+NOTE: Zcmt is primarily targeted at embedded class CPUs due to implementation complexity. Additionally, it is not compatible with architecture class profiles.
 
 The Zcmt extension depends on the <<Zca>> and Zicsr extensions.
 

--- a/Zc-specification/pushpop.adoc
+++ b/Zc-specification/pushpop.adoc
@@ -31,7 +31,7 @@ PUSH, POP, POPRET are used to reduce the size of function prologues and epilogue
 ** adjusts the stack pointer to destroy the stack frame
 
 . The POPRET instructions
-** pop (load) the registers in the register list from the stack from
+** pop (load) the registers in the register list from the stack frame
 ** _cm.popretz_ also moves zero into _a0_ as the return value
 ** adjust the stack pointer  to destroy the stack frame
 ** execute a _ret_ instruction to return from the function


### PR DESCRIPTION
fixes for:

https://github.com/riscv/riscv-code-size-reduction/issues/190
https://github.com/riscv/riscv-code-size-reduction/pull/202
https://github.com/riscv/riscv-code-size-reduction/pull/203