### PR TITLE
Fix PDF build

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -19,7 +19,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    # runs-on: ubuntu-latest
 
     env:
       APT_PACKAGES_FILE: ${{ github.workspace }}/dependencies/apt_packages.txt


### PR DESCRIPTION
Github recently  changed Ubuntu latest version from 20.04 to 22.04 breaking our PDF build action, this reverts it back to 20.04 so build works 

@cetola 

Signed-off-by: Ibrahim Abu Kharmeh <abukharmeh@gmail.com>