### PR TITLE
Update link to prebuilt GCC in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the the lastest spec:
 GCC toolchains:
 
 - [Build from sources](https://github.com/riscv/riscv-code-size-reduction/tree/main/toolchain)
-- [Prebuilt](https://github.com/Liaoshihua/code-size-reduction-gnu-toolchain)
+- [Prebuilt](https://www.embecosm.com/resources/tool-chain-downloads/#corev)
 
 For details of analysing the `Zc` code-size reduction extensions against your ELF file look here
 


### PR DESCRIPTION
Replaced the link to the prebuilt GCC toolchain with the latest CORE-V build from Embecosm, as that one is tracking the version with Zc* support and is updated with new builds every week.

Signed-off-by: Torbjørn Viem Ness <tovine@users.noreply.github.com>