### PR TITLE
toolchain build: allow install/build/source prefixes to be overridden.

### DIFF
--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -13,7 +13,17 @@ This repository uses submodules for Newlib, GCC and Binutils.
 
 There is a script provided which will build all of the required elements for the toolchain, along with standard libraries
 
-    $ sh gcc.sh
+    $ ./gcc.sh
+
+This script uses the following default paths:
+
+* `INSTALLPREFIX`: prefix/
+* `BUILDPREFIX`: build/
+* `SRCPREFIX`: .
+
+These paths can be overridden as follows:
+
+    $ INSTALLPREFIX=/usr/local ./gcc.sh
 
 ## Install
 

--- a/toolchain/gcc.sh
+++ b/toolchain/gcc.sh
@@ -8,9 +8,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Variables used in this script
-INSTALLPREFIX=${PWD}/install
-BUILDPREFIX=${PWD}/build
-SRCPREFIX=${PWD}
+INSTALLPREFIX=${INSTALLPREFIX:-${PWD}/install}
+BUILDPREFIX=${BUILDPREFIX:-${PWD}/build}
+SRCPREFIX=${SRCPREFIX:-${PWD}}
 DEFAULTARCH=rv32imac
 DEFAULTABI=ilp32
 


### PR DESCRIPTION
INSTALLPREFIX defaults to a local sandbox. It is useful to override this location when invoking the toolchain build script. This is trivial by hand, but in CI/CD environments, modifying the gcc.sh script is a hassle.

This commit maintains the current defaults for INSTALLPREFIX, BUILDPREFIX, and SRCPREFIX, but allows them to be overruled when the script is invoked.