### PR TITLE
Add F/D to Zcf/d's depending relations

### DIFF
--- a/Zc-specification/Zc.adoc
+++ b/Zc-specification/Zc.adoc
@@ -11,7 +11,8 @@
 [width="100%",options=header]
 |====================================================================================
 |Version  | change
-|v1.0.4-1    | Added rule that Zcf imply F and Zcd imply D - discuss in https://github.com/riscv/riscv-code-size-reduction/issues/221
+|v1.0.4-1    | Added rule that Zcf implies F and Zcd implies D - discussed in https://github.com/riscv/riscv-code-size-reduction/issues/221
+
 |v1.0.4      | Resolve https://github.com/riscv/riscv-code-size-reduction/issues/221 - Zcf doesn't exist on RV64 as it contains no instructions
 |v1.0.3-1    | Replace statement about non-idempotent memory handler completing the sequence (non-normative)
 |v1.0.3      | Add definition of Zce

--- a/Zc-specification/Zc.adoc
+++ b/Zc-specification/Zc.adoc
@@ -1,5 +1,5 @@
 :sectnums:
-:version-label: v1.0.4
+:version-label: v1.0.4-1
 :lifecycle-state: ratified
 
 [#Zc]
@@ -11,6 +11,7 @@
 [width="100%",options=header]
 |====================================================================================
 |Version  | change
+|v1.0.4-1    | Added rule that Zcf imply F and Zcd imply D - discuss in https://github.com/riscv/riscv-code-size-reduction/issues/221
 |v1.0.4      | Resolve https://github.com/riscv/riscv-code-size-reduction/issues/221 - Zcf doesn't exist on RV64 as it contains no instructions
 |v1.0.3-1    | Replace statement about non-idempotent memory handler completing the sequence (non-normative)
 |v1.0.3      | Add definition of Zce
@@ -118,14 +119,14 @@ Zcf is the existing set of compressed single precision floating point loads and 
 
 Zcf is only relevant to RV32, it cannot be specified for RV64.
 
-The Zcf extension depends on the <<Zca>> extension.
+The Zcf extension depends on the <<Zca>> and F extensions.
 
 [#Zcd]
 === Zcd 
 
 Zcd is the existing set of compressed double precision floating point loads and stores: _c.fld_, _c.fldsp_, _c.fsd_, _c.fsdsp_.
 
-The Zcd extension depends on the <<Zca>> extension.
+The Zcd extension depends on the <<Zca>> and D extensions.
 
 [#Zcb]
 === Zcb


### PR DESCRIPTION
Add F/D to Zcf/d's depending relations, since Zcf/d need F/D extension to generate instructions as Zca sections said.
https://github.com/riscv/riscv-code-size-reduction/issues/221#issuecomment-1614985667